### PR TITLE
fix not loading of embeddings with kwargs

### DIFF
--- a/pandora/tagger.py
+++ b/pandora/tagger.py
@@ -148,7 +148,7 @@ class Tagger():
     def setup_from_disk(
             config_path,
             train_data=None, dev_data=None, test_data=None, verbose=False,
-            load=False, **kwargs
+            load=False, embed=False, **kwargs
     ):
         """ Command to load the whole tagger through a config.txt file and the path to some data
 
@@ -172,7 +172,7 @@ class Tagger():
                 print("\t{} : {}".format(k, v))
 
         train_data = utils.load_annotated_dir(
-            train_data,
+            directory=train_data,
             format='tab',
             extension='.tab',
             include_pos=params['include_pos'],
@@ -189,9 +189,9 @@ class Tagger():
             train_data=train_data,
         )
 
-        if dev_data is not None:
+        if dev_data:
             dev_data = utils.load_annotated_dir(
-                dev_data,
+                directory=dev_data,
                 format='tab',
                 extension='.tab',
                 include_pos=params['include_pos'],
@@ -204,9 +204,9 @@ class Tagger():
                 raise ValueError('No dev data loaded...')
             data_sets["dev_data"] = dev_data
 
-        if test_data is not None:
+        if test_data:
             test_data = utils.load_annotated_dir(
-                test_data,
+                directory=test_data,
                 format='tab',
                 extension='.tab',
                 include_pos=params['include_pos'],
@@ -219,9 +219,9 @@ class Tagger():
                 raise ValueError('No test data loaded...')
             data_sets["test_data"] = test_data
 
-        if "embed" in kwargs:
+        if embed:
             embed_data = utils.load_annotated_dir(
-                kwargs["embed"],
+                kwargs['embed'],
                 format='tab',
                 extension='.tab',
                 include_pos=False,

--- a/pandora/tagger.py
+++ b/pandora/tagger.py
@@ -156,6 +156,9 @@ class Tagger():
         :param train_data:
         :param dev_data:
         :param test_data:
+        :param verbose:
+        :param load:
+        :param embed:
         :return:
         :rtype: Tagger
         """
@@ -221,7 +224,7 @@ class Tagger():
 
         if embed:
             embed_data = utils.load_annotated_dir(
-                kwargs['embed'],
+                embed,
                 format='tab',
                 extension='.tab',
                 include_pos=False,

--- a/pandora/utils.py
+++ b/pandora/utils.py
@@ -58,7 +58,6 @@ def load_annotated_dir(directory='directory', format='tab',
     ===========
     Supported input data formats are described below.
     """
-
     instances = {'token': []}
     if include_lemma:
         instances['lemma'] = []
@@ -66,6 +65,7 @@ def load_annotated_dir(directory='directory', format='tab',
         instances['pos'] = []
     if include_morph:
         instances['morph'] = []
+
     for root, dirs, files in os.walk(directory):
         for name in sorted(files):
             filepath = os.path.join(root, name)


### PR DESCRIPTION
This should solve the default situation where you don't want to load embedding data. This is undocumented at this stage, so that it is unclear what this option loads: actual data to pretrain on (texts) or pretrained embeddings (as a numpy object?). Both would require new function in `pandora.utils.py`, no?